### PR TITLE
Update tinymlgen.py

### DIFF
--- a/tinymlgen/tinymlgen.py
+++ b/tinymlgen/tinymlgen.py
@@ -7,7 +7,7 @@ def port(model, optimize=False, variable_name='model_data', pretty_print=False):
     converter = tf.lite.TFLiteConverter.from_keras_model(model)
     if optimize:
         if isinstance(optimize, bool):
-            optimizers = [tf.lite.Optimize.OPTIMIZE_FOR_SIZE]
+            optimizers = [tf.lite.Optimize.DEFAULT]
         else:
             optimizers = optimize
         converter.optimizations = optimizers


### PR DESCRIPTION

`OPTIMIZE_FOR_SIZE ` has been deprecated by TensorFlow , I learnt this from the [documentation ](https://www.tensorflow.org/lite/api_docs/python/tf/lite/Optimize)  , This has been replaced by 'DEFAULT', this does the same as `OPTIMIZE_FOR_SIZE ` and `OPTIMIZE_FOR_LATENCY` .